### PR TITLE
Compile fixes

### DIFF
--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -20,10 +20,10 @@
 
 #include "proto/V2x2.h"
 #include "proto/CG023.h"
-#include "proto/BAYANG.h"
-#include "proto/CX10_GREENBLUE.h"
+#include "proto/Bayang.h"
+#include "proto/CX10_GreenBlue.h"
 #include "proto/H7.h"
-#include "proto/SYMAX.h"
+#include "proto/SymaX.h"
 #include "proto/H8_3D.h"
 
 /**

--- a/src/radio/iface_nrf24l01.h
+++ b/src/radio/iface_nrf24l01.h
@@ -124,7 +124,7 @@ uint8_t NRF24L01_ReadReg(uint8_t reg);
 uint8_t NRF24L01_Activate(uint8_t code);
 void NRF24L01_SetTxRxMode(t_TXRX_State mode);
 uint8_t NRF24L01_Reset();
-uint8_t NRF24L01_SetPower(uint8_t power);
+uint8_t NRF24L01_SetPower(t_TX_Power power);
 uint8_t NRF24L01_SetBitrate(uint8_t bitrate);
 
 #endif


### PR DESCRIPTION
Hallo Markus,

vielen Dank für deine Library-Version _nrf24_multipro_!

---

Hi markus,

thanks for your libary version of _nrf24_multipro_!
I had to make to small corrections to make it compile on my system (Linux with avr-gcc 4.81).

In _src/protocol.cpp_ :
Filename fixes for case-sensitive filesystem.

In _src/radio/iface_nrf24l01.h_ :
Type change to fix `undefined reference to `NRF24L01_SetPower(unsigned char)'`error.
